### PR TITLE
Update TinyMCE Premium configuration with environment variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Violet88\TinyMCE\TinyMCEPremiumHandler:
     tinymce_cdn: "https://cdn.tiny.cloud/1" # TinyMCE CDN
 ```
 
+#### Environment Variables
+
+Additionally, you can configure all of the above using environment variables. This is useful if you want to use the same configuration across multiple environments.
+The environment variables are prefixed with `TINYMCE_PREMIUM_` and are all uppercase. The `api_key` environment variable is required.
+
+```bash
+TINYMCE_PREMIUM_API_KEY="your-api-key"
+TINYMCE_PREMIUM_TINYMCE_VERSION="4"
+TINYMCE_PREMIUM_TINYMCE_CDN="https://cdn.tiny.cloud/1"
+```
+
+> Environment variables are always prioritized over the configuration file.
+
 ## Usage
 
 The module can be used in the `_config.php` file to enable TinyMCE premium plugins and set JavaScript config values.

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0",
-        "silverstripe/admin": "^1.0",
-        "php": ">=7.4",
+        "silverstripe/framework": "^4|^5",
+        "silverstripe/admin": "^1|^2",
+        "php": ">=7.4|^8.0",
         "mrclay/jsmin-php": "^2.4"
     },
     "require-dev": {

--- a/src/TinyMCEPremiumHandler.php
+++ b/src/TinyMCEPremiumHandler.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Exception;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Environment;
 use SilverStripe\View\Requirements;
 
 /**
@@ -39,6 +40,11 @@ class TinyMCEPremiumHandler
      * @var string The tinymce cdn to use
      */
     private static string $tinymce_cdn = 'https://cdn.tiny.cloud/1';
+
+    /**
+     * @var string The environment prefix to use when fetching config values from the environment
+     */
+    private static string $environment_prefix = 'TINYMCE_PREMIUM_';
 
     /**
      * @var null|string The resolved tinymce version, set after fetching the version from the cdn
@@ -263,5 +269,24 @@ class TinyMCEPremiumHandler
             return $matches[1];
 
         throw new \Exception('TinyMCE version not found');
+    }
+
+    /**
+     * Get a config value from the environment or the config
+     * @param string $key The key of the config value
+     * @return mixed The config value or null if it doesn't exist
+     * @throws BadMethodCallException If the key is not a string
+     */
+    private function get_config(string $key)
+    {
+        $value = Environment::getEnv(self::$environment_prefix . $key);
+        if ($value !== null && !empty($value))
+            return $value;
+
+        $value = self::config()->get($key);
+        if ($value !== null && !empty($value))
+            return $value;
+
+        return null;
     }
 }

--- a/src/TinyMCEPremiumHandler.php
+++ b/src/TinyMCEPremiumHandler.php
@@ -99,7 +99,7 @@ class TinyMCEPremiumHandler
      */
     public function getApiKey()
     {
-        return trim(self::config()->get('api_key'));
+        return trim(self::get_config('api_key'), '/');
     }
 
     /**
@@ -109,7 +109,7 @@ class TinyMCEPremiumHandler
      */
     public function getTinyMCEVersion()
     {
-        return trim(self::config()->get('tinymce_version'), '/');
+        return trim(self::get_config('tinymce_version'), '/');
     }
 
     /**
@@ -133,7 +133,7 @@ class TinyMCEPremiumHandler
      */
     public function getTinyMCEDN()
     {
-        return trim(self::config()->get('tinymce_cdn'), '/');
+        return trim(self::get_config('tinymce_cdn'), '/');
     }
 
     /**


### PR DESCRIPTION
This pull request updates the TinyMCE Premium configuration to support environment variables. This allows for the same configuration to be used across multiple environments. The `TINYMCE_PREMIUM_` prefix is used for all environment variables, and the `api_key` variable is required. Environment variables take priority over the configuration file.